### PR TITLE
fix(get-typed-value): if shape is value, return shape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "license": "Apache-2.0",
   "main": "api-example-generator.js",
   "keywords": [

--- a/src/ApiExampleGenerator.js
+++ b/src/ApiExampleGenerator.js
@@ -736,7 +736,7 @@ export class ApiExampleGenerator extends AmfHelperMixin(LitElement) {
     if (shape instanceof Array) {
       shape = shape[0];
     }
-    const value = shape['@value'];
+    const value = typeof shape === 'object' ? shape['@value'] : shape;
     if (!value) {
       return value;
     }


### PR DESCRIPTION
https://www.mulesoft.org/jira/browse/AAP-1317

Values inside the `data:value` attribute could be inline.

Example:

```
"data:value": "20"
```

Rather than:

```
"data:value": {
   "@value": "20"
}
```
The code now contemplates this possibility.