### PR TITLE
fix: APIC-391 when property name ends with es, only last character sh…

### DIFF
--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -1750,9 +1750,7 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
    */
   _processDataArrayProperties(doc, node, property, name) {
     let childName;
-    if (name.substr(-2) === 'es') {
-      childName = name.substr(0, name.length - 2);
-    } else if (name.substr(-1) === 's') {
+    if (name.endsWith('s')) {
       childName = name.substr(0, name.length - 1);
     } else {
       childName = name;


### PR DESCRIPTION
…ould be removed in tag name

**Bug**
When the specification contains a NamedExample defines with the following definition:
```
references: 
  - referenceType: Delivery Note 
     referenceValue: '7328'
``` 

and when generating the example as an XML the word reference is missing last character _e_:
```
<references> 
   <referenc> 
      <referenceType>Delivery Note</referenceType> 
      <referenceValue>7328</referenceValue> 
    </referenc> 
</references>
``` 

**Fix**
When property name ends with _es_ or _s_, we remove the ending _s_.