### PR TITLE
Fix example generation for partial models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -820,7 +820,7 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
     }
     if (isArray && this._hasProperty(structure, this.ns.w3.rdfSchema.member)) {
       const key = this._getAmfKey(this.ns.w3.rdfSchema.member);
-      const items = structure[key];
+      const items = this._ensureArray(structure[key]);
       for (let i = 0, len = items.length; i < len; i++) {
         const item = items[i];
         this._jsonFromStructureValue(item, obj, isArray);

--- a/test/api-example-generator.test.js
+++ b/test/api-example-generator.test.js
@@ -1580,6 +1580,16 @@ describe('<api-example-generator>', () => {
           assert.typeOf(result, 'array');
           assert.deepEqual(result, [{ thumb: 'thumb 1', url: 'url 1' }]);
         });
+
+        it('Creates example for array structure when only one item is present', () => {
+          const type = AmfLoader.lookupType(amf, 'ArrayTypeWithExample');
+          const value = getStructuredValue(element, type);
+          const key = element._getAmfKey(element.ns.w3.rdfSchema.member);
+          value[key] = value[key][0];
+          const result = element._jsonFromStructure(value);
+          assert.typeOf(result, 'array');
+          assert.deepEqual(result, [{ thumb: 'thumb 1', url: 'url 1' }]);
+        });
       });
     });
   });


### PR DESCRIPTION
Partial models may bring certain attributes in objects rather than in arrays if there is only one item. So we need to contemplate this and ensure that the value we're extracting is an array in order to iterate over it.