### PR TITLE
Fix example generation for and types

### DIFF
--- a/demo/allof-types/allof-types.yaml
+++ b/demo/allof-types/allof-types.yaml
@@ -1,0 +1,58 @@
+openapi: '3.0.2'
+info:
+  title: Allof types example API
+  version: '1.0'
+
+components:
+  schemas:
+    HttpResponse:
+      description: An HTTP response object
+      type: object
+      properties:
+        statusCode:
+          type: number
+          description: Number of the HTTP response
+        statusText:
+          type: string
+          description: A description of the HTTP response
+    Error:
+      description: Error object caused by an error
+      type: object
+      properties:
+        error:
+          type: string
+          description: The error message
+    HttpError:
+      description: An HTTP response that is an error
+      allOf:
+        - $ref: "components/schemas/HttpResponse"
+        - $ref: "components/schemas/Error"
+      properties:
+        extraProp:
+          type: string
+
+paths:
+  /error:
+    get:
+      responses:
+        200:
+          content:
+            appliication/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /httpResponse:
+    get:
+      responses:
+        200:
+          content:
+            appliication/json:
+              schema:
+                $ref: "#/components/schemas/HttpResponse"
+  /httpError:
+    get:
+      responses:
+        200:
+          content:
+            appliication/json:
+              schema:
+                $ref: "#/components/schemas/HttpError"

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -9,5 +9,6 @@
   "SE-13092/SE-13092.raml": "RAML 1.0",
   "SE-14813/SE-14813.raml": "RAML 1.0",
   "APIC-391/APIC-391.raml": "RAML 1.0",
-  "oas-3-api/oas-3-api.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
+  "oas-3-api/oas-3-api.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
+  "allof-types/allof-types.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -117,6 +117,7 @@ class ComponentDemo extends ApiDemoPage {
       ['APIC-188', 'APIC-188'],
       ['APIC-187', 'APIC-187'],
       ['SE-14813', 'SE-14813'],
+      ['allof-types', 'Allof Types API'],
     ].map(
       ([file, label]) => html`
         <anypoint-item data-src="${file}-compact.json"

--- a/test/ExampleGenerator.test.js
+++ b/test/ExampleGenerator.test.js
@@ -669,6 +669,18 @@ describe('ExampleGenerator', () => {
           const result = element.computeExamples(shape, 'application/json');
           assert.isTrue(result[0].isScalar);
         });
+
+        it('computes consolidated example for and type', async () => {
+          const amf = await AmfLoader.load(
+            /** @type Boolean */ (compact),
+            'allof-types'
+          );
+          const element = new ExampleGenerator(amf);
+          const shape = AmfLoader.lookupType(amf, 'HttpError');
+          const result = element.computeExamples(shape, 'application/json', {});
+          const example = JSON.parse(result[0].value);
+          assert.lengthOf(Object.keys(example), 4);
+        });
       });
     });
   });


### PR DESCRIPTION
`and` types were not generating examples correctly.

When an `and` type is encountered, merge all "inherited" properties to create one consolidated example.