### PR TITLE
Fix JSON structure for empty values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -962,7 +962,7 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
   _getTypedValue(structure) {
     const key = this._getAmfKey(this.ns.aml.vocabularies.data.value);
     let shape = structure[key];
-    if (!shape) {
+    if (shape === null || shape === undefined) {
       return undefined;
     }
     if (Array.isArray(shape)) {

--- a/test/ExampleGenerator.test.js
+++ b/test/ExampleGenerator.test.js
@@ -1573,6 +1573,13 @@ describe('ExampleGenerator', () => {
           return obj;
         }
 
+        function constructShortenedType(type, value) {
+          const obj = {};
+          obj[valueKey] = value;
+          obj[typeKey] = type;
+          return obj;
+        }
+
         it('Returns undefined when no @value', () => {
           const result = element._getTypedValue({});
           assert.isUndefined(result);
@@ -1686,6 +1693,12 @@ describe('ExampleGenerator', () => {
           const result = element._getTypedValue(obj);
           assert.typeOf(result, 'string');
           assert.equal(result, '10');
+        });
+
+        it('Returns empty string value instead of undefined', () => {
+          const obj = constructShortenedType(`${prefix}string`, '');
+          const result = element._getTypedValue(obj);
+          assert.equal(result, '');
         });
       });
     });


### PR DESCRIPTION
When dealing with structured values, it is possible for the value of the property to be an empty string. In this case, we need to return the empty string, instead of undefined. So I changed the check from `!shape` to `shape === null || shape === undefined`

This probably also caused problems for false boolean values.

This problem presents itself when instead of:
```
"doc:id": {
    "@value": ""
}
```

We have:
```
"doc:id": ""
```