### PR TITLE
Fix/nullable property example

### DIFF
--- a/demo/APIC-679/APIC-679.yaml
+++ b/demo/APIC-679/APIC-679.yaml
@@ -1,0 +1,106 @@
+openapi: 3.0.0
+info:
+  title: pedestal-internal-xapi
+  version: 1.0.2
+
+paths:
+  /claims:
+    get:
+      summary: Pet Insurance Claim Summary
+      tags:
+        - Claims
+      responses:
+        '200':
+          description: Pet Insurance Claim Summary
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/claimSummaryResponse"
+        '400':
+          $ref: "#/components/responses/badRequest400"
+        '401':
+          $ref: "#/components/responses/unauthorised401"
+        '404':
+          $ref: "#/components/responses/notFound404"
+        '5XX':
+          $ref: "#/components/responses/serverError5XX"
+
+components:
+  schemas:
+    claimSummaryResponse:
+      type: object
+      properties:
+        receivedDate:
+          type: string
+          format: date
+          nullable: true
+          example: "2021-10-1"
+        closedDate:
+          type: string
+          format: date
+          example: "2021-10-21"
+
+  responses:
+    badRequest400:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            type: object
+          examples:
+            badRequest400:
+              $ref: "#/components/examples/badRequest400"
+    unauthorised401:
+      description: Unauthorised
+      content:
+        application/json:
+          schema:
+            type: object
+          examples:
+            unauthorised401:
+              $ref: "#/components/examples/unauthorised401"
+    serverError5XX:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            type: object
+          examples:
+            serverError5xx:
+              $ref: "#/components/examples/serverError5XX"
+    notFound404:
+      description: Resource Notfound
+      content:
+        application/json:
+          schema:
+            type: object
+          examples:
+            notFound404:
+              $ref: "#/components/examples/notFound404"
+  examples:
+    badRequest400:
+      value:
+        success: false
+        code: 400
+        reasonCode: Bad Request
+        message: Required header Authorization not specified
+    unauthorised401:
+      value:
+        success: false
+        code: 401
+        reasonCode: Unauthorised
+        message: unauthorised request
+    notFound404:
+      value:
+        success: false
+        code: 404
+        reasonCode: Resource Not found
+        message: requested resource not found or does not exist
+    serverError5XX:
+      value:
+        success: false
+        code: 500
+        reasonCode: Internal Server Error
+        message: Internal Server Error

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -13,5 +13,6 @@
   "APIC-499/APIC-499.raml": "RAML 1.0",
   "APIC-655/APIC-655.raml": "RAML 1.0",
   "oas-3-api/oas-3-api.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
-  "allof-types/allof-types.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
+  "allof-types/allof-types.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
+  "APIC-679/APIC-679.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.4.10",
+  "version": "4.4.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.4.10",
+  "version": "4.4.11",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -1364,6 +1364,9 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
           return this._jsonExampleFromProperties(data);
         }
       }
+      if (this._hasType(item, this.ns.aml.vocabularies.shapes.ScalarShape)) {
+        return this._computeJsonScalarValue(item);
+      }
     }
     return undefined;
   }

--- a/test/ExampleGenerator.test.js
+++ b/test/ExampleGenerator.test.js
@@ -2082,6 +2082,51 @@ describe('ExampleGenerator', () => {
     });
   });
 
+  describe('APIC-679', () => {
+    describe('_computeJsonProperyValue()', () => {
+      [
+        ['json+ld data model', false],
+        ['Compact data model', true],
+      ].forEach(([label, compact]) => {
+        describe(String(label), () => {
+          let element;
+          let amf;
+
+          before(async () => {
+            amf = await AmfLoader.load(
+              /** @type Boolean */ (compact),
+              'APIC-679'
+            );
+          });
+
+          beforeEach(async () => {
+            element = new ExampleGenerator(amf);
+          });
+
+          it('Returns value for scalar type nullable property', () => {
+            const props = AmfLoader.lookupTypePropertyRange(
+              amf,
+              'claimSummaryResponse',
+              0
+            );
+            const result = element._computeJsonProperyValue(props);
+            assert.equal(result, '2021-10-1');
+          });
+
+          it('Returns value for node type property', () => {
+            const props = AmfLoader.lookupTypePropertyRange(
+              amf,
+              'claimSummaryResponse',
+              1
+            );
+            const result = element._computeJsonProperyValue(props);
+            assert.equal(result, '2021-10-21');
+          });
+        });
+      });
+    });
+  });
+
   describe('JSON schema processing', () => {
     [
       ['json+ld data model', false],


### PR DESCRIPTION
Bug: nullable property example was empty even though it was defined in the spec
Fix: when computing examples for json union we were only taking into account NodeShape and not ScalarShape properties