### PR TITLE
[W-11843862] Enum example

### DIFF
--- a/demo/W-11843862/W-11843862.yaml
+++ b/demo/W-11843862/W-11843862.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.0
+info:
+  title: eMPF API Specification - Contribution Module
+  description: eMPF API Specification - Contribution Module
+  version: 0.1.0
+paths:
+  /cas/ad/contribution/external/v1/bill/list:
+    get:
+      tags:
+        - ER-Portal-API
+      summary: CON-PERIOD-BILLABLE CON - Retrieve period bill
+      description: |
+        **API ID:** CON-PERIOD-BILLABLE \
+        **CM:** CM-Web-Employer-Contribution A1, A2, A3, A4, B1, B2, B3, B4 \
+        **FS:** FS-UF-CON-REE-009,FS-UF-CON-CEE-001 \
+        CON - Retrieve period bill
+      parameters:
+        - $ref: '#/components/parameters/x-empf-apiclient-id'
+      responses:
+        '200':
+          description: successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/periodBillableResponse'
+      security:
+        - bearerAuth: []
+
+components:
+  parameters:
+    x-empf-apiclient-id:
+      in: header
+      name: x-empf-apiclient-id
+      description: value should be an integer starting from 1 representing the identity of the API client, 1 for ER Portal, 2 for ER Mobile App, 3 for EE Portal, 4  for EE Mobile App, 5 for admin, 6 for trustee, 7 for mpfa, 8 for kiosk
+      schema:
+        type: integer
+        enum:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+      required: true
+
+  schemas:
+    GlobalSuccessResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: The flag indicates there is no bussiness error occurred in the request
+        code:
+          type: integer
+          example: '200'
+    periodBillableResponse:
+      allOf:
+        - $ref: '#/components/schemas/GlobalSuccessResponse'
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/demo/index.js
+++ b/demo/index.js
@@ -123,6 +123,8 @@ class ComponentDemo extends ApiDemoPage {
       ['APIC-391', 'APIC-391'],
       ['APIC-655', 'APIC-655'],
       ['xml-api', 'xml-api'],
+      ['W-11843862', 'W-11843862'],
+      ['v4_0_0_api_specs', 'v4_0_0_api_specs']
     ].map(
       ([file, label]) => html`
         <anypoint-item data-src="${file}-compact.json"

--- a/demo/model.js
+++ b/demo/model.js
@@ -27,5 +27,6 @@ files.set('allof-types/allof-types.yaml', { type: 'OAS 3.0', mime: 'application/
 files.set('APIC-679/APIC-679.yaml', { type: 'OAS 3.0', mime: 'application/yaml' });
 files.set('xml-api/xml-api.yaml', { type: 'OAS 3.0', mime: 'application/yaml' });
 files.set('v4_0_0_api_spec/v4_0_0_api_specs.yaml', { type: 'OAS 3.0', mime: 'application/yaml' });
+files.set('W-11843862/W-11843862.yaml', { type: 'OAS 3.0', mime: 'application/yaml' });
 
 generator.generate(files);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.4.19",
+  "version": "4.4.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.4.19",
+  "version": "4.4.20",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ExampleGenerator.d.ts
+++ b/src/ExampleGenerator.d.ts
@@ -334,6 +334,14 @@ declare class ExampleGenerator extends AmfHelperMixin(Object) {
   _computeDefaultRangeValue(range: object): string | number | boolean | null;
 
   /**
+   * Computes default enum value for given range.
+   *
+   * @param {Object} range AMF's range definition for a shape.
+   * @return {string|number|boolean|null} Value cast to the corresponding type
+   */
+  _computeDefaultEnumRangeValue(range: object): string | number | boolean | null;
+
+  /**
    * Casts the value to given data type represented in AMF notation.
    *
    * @param value Value encoded in AMF

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -1327,6 +1327,31 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
   }
 
   /**
+   * Computes default enum value for given range.
+   *
+   * @param {Object} range AMF's range definition for a shape.
+   * @return {string|number|boolean|null} Value cast to the corresponding type
+   */
+  _computeDefaultEnumRangeValue(range) {
+    let enumOptions = range[this._getAmfKey(this.ns.w3.shacl.in)]
+    if (Array.isArray(enumOptions)) {
+      [enumOptions] = enumOptions;
+    }
+    const rdfKey = this._getAmfKey(this.ns.w3.rdfSchema.key);
+    const firstOptionKey = Object.keys(enumOptions).find((key) => key.indexOf(rdfKey) !== -1);
+    let firstOption = enumOptions[firstOptionKey];
+    if (Array.isArray(firstOption)) {
+      [firstOption] = firstOption;
+    }
+    const vKey = this._getAmfKey(this.ns.raml.vocabularies.data.value);
+    const value = this._getValue(firstOption, vKey);
+    if (value) {
+      return value;
+    }
+    return null;
+  }
+
+  /**
    * Computes default value for given range.
    *
    * This is to work with mocking services when the user just want to send an
@@ -1338,6 +1363,14 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
    * @return {string|number|boolean|null} Value casted to the corresponding type
    */
   _computeDefaultRangeValue(range) {
+    const isEnum = this._hasProperty(range, this.ns.w3.shacl.in)
+    if (isEnum) {
+      const value = this._computeDefaultEnumRangeValue(range);
+      if (value) {
+        return value;
+      }
+    }
+
     const type = this._computeScalarType(range);
     switch (type) {
       case 'Number':

--- a/test/ExampleGenerator.test.js
+++ b/test/ExampleGenerator.test.js
@@ -2321,7 +2321,7 @@ describe('ExampleGenerator', () => {
           schema = element._resolve(schema);
           const result = element._computeJsonPropertyValue(schema);
           assert.typeOf(result, 'object');
-          assert.deepEqual(result, { messages: [{ "referrers": "", "sequenceId": 1, "text": "", "type": "", "tz": "", "variables": "" }]})
+          assert.deepEqual(result, { messages: [{ "referrers": "", "sequenceId": 1, "text": "", "type": "init", "tz": "", "variables": "" }]})
         });
       });
     });

--- a/test/W-11843862.test.js
+++ b/test/W-11843862.test.js
@@ -1,0 +1,38 @@
+import { fixture, assert, html } from '@open-wc/testing';
+import { AmfLoader } from './amf-loader.js';
+import '../api-example-generator.js';
+
+describe('W-11843862', () => {
+  async function basicFixture(amf) {
+    return fixture(html`<api-example-generator
+      .amf="${amf}"
+    ></api-example-generator>`);
+  }
+
+  const apiFile = 'W-11843862';
+
+  [
+    ['json+ld data model', false],
+    ['Compact data model', true],
+  ].forEach(([label, compact]) => {
+    describe(/** @type {string} */ (label), () => {
+      let element;
+      let amf;
+
+      before(async () => {
+        amf = await AmfLoader.load(/** @type {boolean} */ (compact), apiFile);
+      });
+
+      beforeEach(async () => {
+        element = await basicFixture(amf);
+      });
+
+      it('Returns first enum option as example', () => {
+        const headers = AmfLoader.lookupExpectsHeaderSchema(amf, '/cas/ad/contribution/external/v1/bill/list', 'get');
+        const examples = element.computeExamples(headers[0], 'application/json', {});
+        assert.lengthOf(examples, 1);
+        assert.equal(examples[0].value, '1')
+      });
+    });
+  });
+});

--- a/test/amf-loader.js
+++ b/test/amf-loader.js
@@ -67,6 +67,24 @@ AmfLoader.lookupPayload = function(model, endpoint, operation) {
 };
 
 /**
+ * Looks for headers in an operation
+ * @param {any} model
+ * @param {string} endpoint Endpoint's path
+ * @param {string} operation Operation name (lowercase)
+ * @return {Array<Object>}
+ */
+AmfLoader.lookupExpectsHeaderSchema = function(model, endpoint, operation) {
+  const op = AmfLoader.lookupOperation(model, endpoint, operation);
+  const expects = helper._computeExpects(op);
+  if (!expects) {
+    throw new Error(`The ${operation.toUpperCase()} ${endpoint} operation has no request definition.`);
+  }
+  const headers = helper._computeHeaders(expects);
+  const sKey = helper._getAmfKey(helper.ns.aml.vocabularies.shapes.schema);
+  return headers[0][sKey];
+};
+
+/**
  * Looks for a payload in the responses list of an operation
  * @param {any} model
  * @param {string} endpoint Endpoint's path


### PR DESCRIPTION
Bug fixed.
Example for enum type was based on the type and not the valid options. For example, for this type

```
schema:
        type: integer
        enum:
          - 1
          - 2
          - 3
          - 4
          - 5
          - 6
          - 7
```

we were returning 0 as it is the default value for integers but it should be 1.