### PR TITLE
[W-12428170] Missing allOf info

### DIFF
--- a/demo/W-12428170/W-12428170.yaml
+++ b/demo/W-12428170/W-12428170.yaml
@@ -1,0 +1,69 @@
+swagger: "2.0"
+info:
+  description: "UPM Party Services"
+  version: 1.0.0
+  title: UPM Party Services
+  contact:
+    email: CustomerMDM@internal.toyota.com
+schemes:
+  - https
+
+paths:
+  /customers/preferences/search:
+    post:
+      summary: "Search customer preferences"
+      description: "Search customer preferences"
+      produces:
+        - application/json
+      consumes:
+        - application/json
+      tags:
+        - Search Services
+      responses:
+        "200":
+          description: "Get Address search response"
+          schema:
+            $ref: "#/definitions/preferencesSearchDTO"
+
+definitions:
+  preferencesSearchDTO:
+    type: object
+    properties:
+      Account:
+        type: "array"
+        items:
+          $ref: "#/definitions/PreferenceSearchAccount"
+  PreferenceSearchAccount:
+    type: object
+    allOf:
+      - $ref: "#/definitions/AccountBaseDTO"
+    properties:
+      Collateral:
+        type: "array"
+        items:
+          $ref: "#/definitions/CollateralDemographicsSearch"
+      Contact:
+        type: "array"
+        items:
+          $ref: "#/definitions/SearchPreferenceContactDTO"
+  CollateralDemographicsSearch:
+    type: object
+    properties:
+      collateralId:
+        type: string
+        description: collateral id vin or hin or etc
+        example: "123"
+  SearchPreferenceContactDTO:
+    type: object
+    properties:
+      upid:
+        type: string
+        example: "053fa2ac-4afd-4dac-9ba4-d1201ed919b1"
+        description: "Customer UPID"
+  AccountBaseDTO:
+    type: object
+    properties:
+      applicationId:
+        type: string
+        example: ""
+        description: "Application ID"

--- a/demo/model.js
+++ b/demo/model.js
@@ -28,5 +28,6 @@ files.set('APIC-679/APIC-679.yaml', { type: 'OAS 3.0', mime: 'application/yaml' 
 files.set('xml-api/xml-api.yaml', { type: 'OAS 3.0', mime: 'application/yaml' });
 files.set('v4_0_0_api_spec/v4_0_0_api_specs.yaml', { type: 'OAS 3.0', mime: 'application/yaml' });
 files.set('W-11843862/W-11843862.yaml', { type: 'OAS 3.0', mime: 'application/yaml' });
+files.set('W-12428170/W-12428170.yaml', { type: 'OAS 2.0', mime: 'application/yaml' });
 
 generator.generate(files);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.4.21",
+  "version": "4.4.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.4.21",
+  "version": "4.4.22",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -1525,6 +1525,13 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
         }
       }
     }
+    const properties = this._ensureArray(range[pKey])
+    if (properties) {
+      const propertiesExamples = this._jsonExampleFromProperties(properties)
+      if (propertiesExamples && typeof propertiesExamples === 'object') {
+        examples.push(propertiesExamples);
+      }
+    }
     return examples.reduce((acc, value) => ({...acc, ...value}), {});
   }
 

--- a/test/ExampleGenerator.test.js
+++ b/test/ExampleGenerator.test.js
@@ -2327,6 +2327,42 @@ describe('ExampleGenerator', () => {
     });
   });
 
+  describe('W-12428170', () => {
+    [
+      ['json+ld data model', false],
+      ['Compact data model', true],
+    ].forEach((args) => {
+      const label = args[0];
+      const compact = /** @type boolean */ (args[1]);
+
+      describe(String(label), () => {
+        /** @type ExampleGenerator */
+        let element;
+        let amf;
+        let prefix;
+
+        before(async () => {
+          amf = await AmfLoader.load(compact, 'W-12428170');
+        });
+
+        beforeEach(async () => {
+          element = new ExampleGenerator(amf);
+          prefix = element._getAmfKey(element.ns.w3.xmlSchema.key);
+          if (prefix !== element.ns.w3.xmlSchema.key) {
+            prefix += ':';
+          }
+        });
+
+        it('returns value for array type with allOf items', () => {
+          let properties = AmfLoader.lookupTypeProperties(amf, "PreferenceSearchAccount");
+          const result = element._exampleFromProperties(properties, 'application/json', 'preferencesSearchDTO');
+          assert.typeOf(result, 'object');
+          assert.deepEqual(result.value,   "{\n  \"Collateral\": [\n    {\n      \"collateralId\": \"123\"\n    }\n  ],\n  \"Contact\": [\n    {\n      \"upid\": \"053fa2ac-4afd-4dac-9ba4-d1201ed919b1\"\n    }\n  ]\n}")
+        });
+      });
+    });
+  });
+
   describe('APIC-679', () => {
     describe('_computeJsonPropertyValue()', () => {
       [


### PR DESCRIPTION
Bug: When rendering the properties for a type that is using both "allOf" and "properties" we are not showing the full set of information.

Fix: When generating example for type, take into account both allOf and properties nodes.

Before: showing only properties coming from allOf 
![Screenshot 2023-01-25 at 15 39 55](https://user-images.githubusercontent.com/13999213/214655368-817e505b-3a7a-488b-ba55-caeebdd059a0.png)
After: showing both allOf props and props
![Screenshot 2023-01-25 at 15 39 35](https://user-images.githubusercontent.com/13999213/214655374-6ee64bc8-642e-4f97-bbe8-559ec5631575.png)
