### PR TITLE
Fix/w 14278539/example-nulleable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.4.23",
+  "version": "4.4.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.4.23",
+  "version": "4.4.24",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -1274,7 +1274,20 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
           }
         });
       } else {
-        let value = this._computeJsonPropertyValue(range);
+        const aKey = this._getAmfKey(this.ns.aml.vocabularies.shapes.anyOf);
+        let value 
+        const anyOf = this._ensureArray(range[aKey]);
+        if(anyOf){
+          for(let anyOfIndex=0; i<anyOf.length; anyOfIndex++) {
+            const exampleValue = this._computeJsonPropertyValue(anyOf[anyOfIndex]);
+            if(exampleValue!==null){
+              value = exampleValue;
+              break;
+            }
+          }
+        }else{
+          value = this._computeJsonPropertyValue(range);
+        }
         if (value === undefined) {
           value = '';
         }


### PR DESCRIPTION
When property has nullable option the complete example didn't show.

![image](https://github.com/advanced-rest-client/api-example-generator/assets/95221374/75eb2120-fa3f-4ef4-bc03-61e8a5449721)


Now is finding anyof property in model 

![image](https://github.com/advanced-rest-client/api-example-generator/assets/95221374/2cfdf36d-87d0-4bfb-a0e8-96f5f893b85f)


