### PR TITLE
[W-14651311] add attribute to xml property when has example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.4.25",
+  "version": "4.4.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.4.25",
+  "version": "4.4.26",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -1735,6 +1735,13 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
           this.ns.w3.shacl.name
         ));
       }
+      if (serialization) {
+        if (xmlAttribute) {
+        
+          this._appendXmlAttribute(node, range, xmlName, examples[0]);
+          return;
+        }
+      }
       this._xmlFromExamples(doc, node, examples[0], name, { xmlPrefix });
       return;
     }
@@ -1818,7 +1825,7 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
    * @param {Object} range AMF range
    * @param {String} xmlName Value of 'xmlName' property of AMF's object
    */
-  _appendXmlAttribute(node, range, xmlName) {
+  _appendXmlAttribute(node, range, xmlName, example) {
     let name = /** @type {string} */ xmlName;
     if (!name) {
       name = /** @type {string} */ (this._getValue(
@@ -1832,11 +1839,23 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
     if (name.indexOf('?') !== -1) {
       name = name.replace('?', '');
     }
-    let value = this._readDataType(range);
-    if (!value) {
-      value = '';
+    let exampleValue;
+    if (example) {
+      const sKey = this._getAmfKey(
+        this.ns.aml.vocabularies.document.structuredValue
+      );
+      const structure = example[sKey];
+      exampleValue = this._computeStructuredExampleValue(structure[0]);
     }
-    node.setAttribute(name, value);
+    if (exampleValue) {
+      node.setAttribute(name, String(exampleValue));
+    } else {
+      let value = this._readDataType(range);
+      if (!value) {
+        value = '';
+      }
+      node.setAttribute(name, value);
+    }
   }
 
   /**


### PR DESCRIPTION
Description:

We should show example XML to OAS Rest API's

Steps to reproduce:

Build or view in Desging center OAS API Spec attached
Go to books/recommendations
Go to POST
In the Panel Documentation not show payload example


Current Behaviour:

Not show example payload

Expected Behaviour:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Book LocationAttr1="Sample1" LocationRefs3="SampleId" LocationAttr="string" LocationRefs="SampleId">
  <author_name></author_name>
  <book_title>Rob</book_title>
  <pages>200</pages>
  <genre></genre>
  <id></id>
</Book>
````

### result

<img width="1758" alt="Screenshot 2023-12-19 at 15 17 34" src="https://github.com/advanced-rest-client/api-example-generator/assets/96145153/9208187c-cc88-46eb-a4dd-71115c27a375">

### spec
[00388196-test.zip](https://github.com/advanced-rest-client/api-example-generator/files/13719079/00388196-test.zip)

