### PR TITLE
[W-14651333] difference in order of example payload in exchange and acm

### DIFF
--- a/src/ExampleGenerator.d.ts
+++ b/src/ExampleGenerator.d.ts
@@ -533,4 +533,11 @@ declare class ExampleGenerator extends AmfHelperMixin(Object) {
    * @return {XmlData}
    */
   _computeXmlSerializationData(serialization): object;
+
+  /**
+   * Generate JSON example string value from raw value definition.
+   * @param {string} raw 
+   * @return {string}
+   */
+  computeRaw(raw: string): string
 }

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -757,6 +757,15 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
         }
       });
       if (isJson) {
+        if (result.raw) {
+          try {
+            result.value = this.computeRaw(raw)
+            return result 
+          } catch (_) {
+            // ...
+          }
+        } 
+
         result.value = JSON.stringify(parts, null, 2);
         return result;
       }
@@ -791,6 +800,31 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
     }
     return undefined;
   }
+
+  /**
+   * @param {String} raw 
+   * @returns string JSON formatted
+   */
+  computeRaw (raw) {
+    const accountEntries = raw.split('-\n');
+    const accounts = [] 
+    for (const entry of accountEntries) {
+      if (entry !== '') {
+        const lines = entry.split('\n');
+        const account = {};
+        for (const line of lines) {
+          if (line !== '') {
+            const [key, value] = line.split(': ');
+            account[key.trim()] =  Number(value) ?  Number(value) : value.trim()
+          }
+        }
+        accounts.push(account);
+      }
+    }
+    const jsonString = JSON.stringify(accounts, null, 2);
+    return jsonString;
+  }
+  
 
   /**
    * Computes list of examples for an array shape.

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -757,6 +757,8 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
         }
       });
       if (isJson) {
+        // if raw (original example) exists try to parse it to JSON  
+        // if the parse process fails then use parts to build example value
         if (result.raw) {
           try {
             result.value = this.computeRaw(raw)

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -807,7 +807,7 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
    */
   computeRaw (raw) {
     const accountEntries = raw.split('-\n');
-    const accounts = [] 
+    const accounts = [];
     for (const entry of accountEntries) {
       if (entry !== '') {
         const lines = entry.split('\n');
@@ -821,8 +821,7 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
         accounts.push(account);
       }
     }
-    const jsonString = JSON.stringify(accounts, null, 2);
-    return jsonString;
+    return JSON.stringify(accounts, null, 2);
   }
   
 

--- a/test/ExampleGenerator.test.js
+++ b/test/ExampleGenerator.test.js
@@ -3163,4 +3163,27 @@ describe('ExampleGenerator', () => {
       });
     });
   });
+
+  describe('computeRaw', () => {
+    [
+      ['json+ld data model', false],
+      ['Compact data model', true],
+    ].forEach((args) => {
+      const compact = /** @type boolean */ (args[1]);
+      /** @type ExampleGenerator */
+      let element;
+      let amf;
+
+      beforeEach(async () => {
+        amf = await AmfLoader.load(/** @type Boolean */(compact));
+        element = new ExampleGenerator(amf);
+      });
+
+      it('should correctly transform raw string to JSON', () => {
+        const raw = "-\n  balance: 200\n  approval-status: P\n  account-id: de7228b9-f6bb-4261-9d17-a3ddd5802e03\n  account-name: Plaid Saving\n  account-number: '1111222233331111'\n  account-routing-number: '123123123'\n  institution-name: Sample Bank\n  institution-id: b3dedb19-157c-4239-880f-a125ef4384e2\n  created-by: WREX\n  modified-by: WREX\n  created-at: February 19, 2023, 3:16:01 AM\n  modified-at: February 19, 2023, 3:16:01 AM\n-\n  balance: 100\n  approval-status: P\n  account-id: e7bb8f6d-fdc0-4873-9609-d2f2713900ed\n  account-name: Plaid Checking\n  account-number: '1111222233330000 '\n  account-routing-number: '123123123'\n  institution-name: Sample Bank\n  institution-id: b3dedb19-157c-4239-880f-a125ef4384e2\n  created-by: WREX\n  modified-by: WREX\n  created-at: February 19, 2023, 3:16:01 AM\n  modified-at: February 19, 2023, 3:16:01 AM";
+        const expectedJson = '[\n  {\n    "balance": 200,\n    "approval-status": "P",\n    "account-id": "de7228b9-f6bb-4261-9d17-a3ddd5802e03",\n    "account-name": "Plaid Saving",\n    "account-number": "\'1111222233331111\'",\n    "account-routing-number": "\'123123123\'",\n    "institution-name": "Sample Bank",\n    "institution-id": "b3dedb19-157c-4239-880f-a125ef4384e2",\n    "created-by": "WREX",\n    "modified-by": "WREX",\n    "created-at": "February 19, 2023, 3:16:01 AM",\n    "modified-at": "February 19, 2023, 3:16:01 AM"\n  },\n  {\n    "balance": 100,\n    "approval-status": "P",\n    "account-id": "e7bb8f6d-fdc0-4873-9609-d2f2713900ed",\n    "account-name": "Plaid Checking",\n    "account-number": "\'1111222233330000 \'",\n    "account-routing-number": "\'123123123\'",\n    "institution-name": "Sample Bank",\n    "institution-id": "b3dedb19-157c-4239-880f-a125ef4384e2",\n    "created-by": "WREX",\n    "modified-by": "WREX",\n    "created-at": "February 19, 2023, 3:16:01 AM",\n    "modified-at": "February 19, 2023, 3:16:01 AM"\n  }\n]';
+        assert.equal(element.computeRaw(raw), expectedJson);
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Issue type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description
In ExampleGenerator component, method _jsonFromStructure

Object.keys(structure) -> return different order in salesforce and local demo. One possible solution is order array by @id prop before execute Object.keys(structure)

### UI screenshots with changes


https://github.com/mulesoft/api-console-lwc/assets/96145153/5796b34a-37fb-41a2-8b53-051dbb35a068



### Checklist:
- [x] The branch name follows branching convention: fix/W-x/*, feat/W-x/*, test/W-x/* or chore/W-x/*
- [x] The PR title have the GUS ticket [W-xxxxx]
- [x] The PR is rebased with base branch
- [ ] The PR requires a meeting with the reviewers to guide them through the changes
- [x] I added tests
- [x] I validated the fix manually
- [x] I have performed a self-review of my own code
- [ ] This change requires documentation update
- [ ] This change includes library / dependency update
- [x] My changes generate no new warnings