### PR TITLE
[W-14874965] Swagger-Json-file-not-displaying-valid-Json-examples-in-response-in-Design-center-and-Exchange

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -271,9 +271,9 @@
       }
     },
     "@api-components/amf-helper-mixin": {
-      "version": "4.5.20",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.20.tgz",
-      "integrity": "sha512-G/Uvlncl5nkLki4gMIcse9lkNAtEAJKYVJjVvZL/WBET0yS6uS1E1lURLequ9/NizzmjChWxmIGblCjrBeKZTQ==",
+      "version": "4.5.24",
+      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.5.24.tgz",
+      "integrity": "sha512-rxjh+9X4OC0pFbYsqXTmiGTr8JM2xkc/oIyGuW9Ez+CKFcF6tb/7xcog5ZC/9CUQHfa5bFrJ5qXH+wjRyMx3hA==",
       "requires": {
         "amf-json-ld-lib": "0.0.14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-example-generator",
-  "version": "4.4.27",
+  "version": "4.4.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-example-generator",
   "description": "Examples generator from AMF model",
-  "version": "4.4.27",
+  "version": "4.4.28",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "email": "arc@mulesoft.com"
   },
   "dependencies": {
-    "@api-components/amf-helper-mixin": "^4.1.8",
+    "@api-components/amf-helper-mixin": "^4.5.24",
     "lit-element": "^2.4.0"
   },
   "devDependencies": {

--- a/src/ExampleGenerator.js
+++ b/src/ExampleGenerator.js
@@ -1635,9 +1635,17 @@ export class ExampleGenerator extends AmfHelperMixin(Object) {
   _computeJsonObjectValue(range) {
     const pKey = this._getAmfKey(this.ns.w3.shacl.property);
     const properties = this._ensureArray(range[pKey]);
+
+    const additionalPropertiesKey = this._getAmfKey(this.ns.w3.shacl.additionalPropertiesSchema);
+    const additionalProperties = this._ensureArray(range[additionalPropertiesKey]);
+
     if (properties && properties.length) {
       return this._jsonExampleFromProperties(properties);
     }
+    if (additionalProperties && additionalProperties.length) {
+      return this._jsonExampleFromProperties(this._ensureArray(additionalProperties[0][pKey]));
+    }
+
     return {};
   }
 


### PR DESCRIPTION
- Add map for additionalPropertiesSchema in _computeJsonObjectValue method in ExampleGenerator.js
- Update amf-helper-mixin-lib to 4.5.24